### PR TITLE
support specifying custom database url for tests

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -37,4 +37,4 @@ jobs:
             - name: Run Tests
               run: go test -v ./...
               env:
-                  POSTGRES_PASSWORD: oui
+                  POSTGRES_URL: postgresql://oui:oui@localhost/oui?sslmode=disable

--- a/oui/db_test.go
+++ b/oui/db_test.go
@@ -1,7 +1,6 @@
 package oui_test
 
 import (
-	"fmt"
 	"os"
 	"path/filepath"
 	"testing"
@@ -19,9 +18,8 @@ func Test_New(t *testing.T) {
 
 	t.Run("postgres", func(t *testing.T) {
 		t.Parallel()
-		password := os.Getenv("POSTGRES_PASSWORD")
-		require.NotEqual(t, "", password, "missing POSTGRES_PASSWORD environment variable")
-		cs := fmt.Sprintf("postgresql://oui:%s@localhost/oui?sslmode=disable", password)
+		cs := os.Getenv("POSTGRES_URL")
+		require.NotEqual(t, "", cs, "missing POSTGRES_URL environment variable")
 		psql, err := oui.CreatePostgresOption(cs)
 		require.NoError(t, err)
 		ouidb, err := oui.New(oui.WithVersion("test"), psql)


### PR DESCRIPTION
We need this in Nixpkgs packaging to provide the postgres database as a unix socket